### PR TITLE
feat: variant fix, add arrays and matrices example

### DIFF
--- a/examples/TestServer/main.cpp
+++ b/examples/TestServer/main.cpp
@@ -88,6 +88,38 @@ void TestServer::initialise()
             cout << "Failed to set value callback" << endl;
         }
     }
+    
+   //Example adding an array by setting it with setArrayCopy
+    Open62541::NodeId setArrayCopy_array_id(_idx, "Array_By_Copy");
+    UA_Double setArrayCopy_temp_array[4] = {1.0, 2.0, 3.0, 4.0};
+    const size_t array_size = 4;
+    Open62541::Variant setArrayCopy_variant;
+    setArrayCopy_variant.setArrayCopy(&setArrayCopy_temp_array, array_size, &UA_TYPES[UA_TYPES_DOUBLE]);
+    addVariable(Open62541::NodeId::Objects, "Array_By_Copy", setArrayCopy_variant , setArrayCopy_array_id, Open62541::NodeId::Null);
+
+    //Example adding an array by setting it with setArray as a child for Array_With_Copy
+    Open62541::NodeId setArray_array_id(_idx, "Array_By_Set");
+    Open62541::Variant setArray_variant;
+    const size_t setArray_array_size = 3;
+    UA_Double *setArray_array = (UA_Double *) UA_Array_new(3, &UA_TYPES[UA_TYPES_DOUBLE]);
+    setArray_array[0] = 1;
+    setArray_array[1] = 3;
+    setArray_array[2] = 5;
+    setArray_variant.setArray(setArray_array , setArray_array_size, &UA_TYPES[UA_TYPES_DOUBLE]);
+    addVariable(setArrayCopy_array_id, "Array_By_Set", setArray_variant , setArray_array_id, Open62541::NodeId::Null);
+
+    //Example adding a matrix 
+    Open62541::NodeId test_matrix_id(_idx, "Matrix_Example");
+    Open62541::VariableAttributes vattr;
+    Open62541::Variant vattr_value;
+    //set required dimensions and values for the matrix
+    UA_Double matrix_temp_array[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    UA_Int32 rows = 3;
+    UA_Int32 cols = 2;
+    size_t matrix_dims = 2;
+    int value_rank = 2;
+    vattr_value = vattr.getVariantMatrix(rows, cols, matrix_dims, &UA_TYPES[UA_TYPES_DOUBLE], value_rank, &matrix_temp_array);
+    addVariable(Open62541::NodeId::Objects, "Matrix_Example", vattr_value, test_matrix_id, Open62541::NodeId::Null);
 
     // Set up an event source - monitor this item to get the events in UA Expert
     _testTriggerSource.notNull();
@@ -116,7 +148,7 @@ void TestServer::initialise()
     //
     // Define an object type
     //
-    Open62541::NodeId testType(_idx, "TestObjectType");
+    Open62541::NodeId testType(_idx, "AR_ObjectType");
     if (!_object.addType(testType)) {
         cout << "Failed to create object type" << endl;
     }

--- a/examples/TestServer/testmethod.h
+++ b/examples/TestServer/testmethod.h
@@ -4,35 +4,35 @@
 #include <open62541cpp/servermethod.h>
 class TestMethod : public Open62541::ServerMethod
 {
-    Open62541::Argument inputArgument1;  // argument definitions must persist because shallow copies used of UA_Argument
-    Open62541::Argument inputArgument2;  //
-    Open62541::Argument outputArguments;
+    Open62541::Argument inputArgument1; // argument definitions must persist because shallow copies used of UA_Argument
+    Open62541::Argument inputArgument2; //
+    Open62541::Argument outputArguments1;
+    Open62541::Argument outputArguments2;
 
 public:
-    TestMethod()
-        : Open62541::ServerMethod("AddNumbers", 2, 1)
+    TestMethod() : Open62541::ServerMethod("AddNumbers",2,2)
     {
-        in()[0]  = inputArgument1.set(UA_TYPES_DOUBLE, "Argument 1", "Argument 1");
-        in()[1]  = inputArgument2.set(UA_TYPES_DOUBLE, "Argument 2", "Argument 2");
-        out()[0] = outputArguments.set(UA_TYPES_DOUBLE, "Sum", "Addition of Numbers");
-        setFunction([](Open62541::Server& /*server*/,
-                       const UA_NodeId* /*objectId*/,
-                       size_t inputSize,
-                       const UA_Variant* input,
-                       size_t outputSize,
-                       UA_Variant* output) {
+        in()[0] = inputArgument1.set(UA_TYPES_DOUBLE,"Argument 1","Argument 1");
+        in()[1] = inputArgument2.set(UA_TYPES_DOUBLE,"Argument 2","Argument 2");
+        out()[0] = outputArguments1.set(UA_TYPES_DOUBLE,"Sum","Addition of Numbers");
+        out()[1] = outputArguments2.set(UA_TYPES_STRING,"Output string","test a sting");
+
+        setFunction( [](Open62541::Server &/*server*/,const UA_NodeId */*objectId*/, size_t inputSize, const UA_Variant *input, size_t outputSize,UA_Variant *output) {
+            
             // This method adds two numbers and returns the result
-            if (inputSize == 2 && outputSize == 1)  // validate argument lists are the correct length
+            if(inputSize == 2 && outputSize == 2) // validate argument lists are the correct length
             {
-                UA_Double* arg1 = (UA_Double*)input[0].data;  // assume double - but should validate
-                UA_Double* arg2 = (UA_Double*)input[1].data;
-                double sum      = *arg1 + *arg2;
-                Open62541::Variant out_var(sum);
-                out_var.assignTo(*output);
+                UA_Double *arg1 = (UA_Double *)input[0].data; // assume double - but should validate
+                UA_Double *arg2 = (UA_Double *)input[1].data;
+                double sum = *arg1 + *arg2;
+                Open62541::String test_string("This is a 2nd Test Output argument of type String");
+                UA_Variant_setScalarCopy(&output[0], &sum, &UA_TYPES[UA_TYPES_DOUBLE]);
+                UA_Variant_setScalarCopy(&output[1], &test_string, &UA_TYPES[UA_TYPES_STRING]);
             }
             return UA_StatusCode(UA_STATUSCODE_GOOD);
         });
     }
+
 };
 
-#endif  // TESTMETHOD_H
+#endif // TESTMETHOD_H

--- a/examples/TestServer/testobject.h
+++ b/examples/TestServer/testobject.h
@@ -1,22 +1,25 @@
 #ifndef TESTOBJECT_H
 #define TESTOBJECT_H
 #include <open62541cpp/serverobjecttype.h>
+#include <open62541cpp/propertytree.h>
+#include <open62541cpp/open62541objects.h>
 #include "testmethod.h"
 // Object Type Example
 class TestObject : public Open62541::ServerObjectType
 {
 public:
     TestObject(Open62541::Server& s)
-        : ServerObjectType(s, "TestObject")
+        : ServerObjectType(s, "AR_ObjectType")
     {
     }
-
     bool addChildren(const Open62541::NodeId& parent) override
     {
         Open62541::NodeId n;
         Open62541::NodeId a;
+        Open62541::NodeId b;
         return addObjectTypeVariable<double>("Current", parent, n.notNull()) &&
-               addObjectTypeVariable<double>("Average", parent, a.notNull());
+               addDerivedObjectType ("Golash", parent, a.notNull())&&
+               addObjectTypeArrayVariable<int, 5>("Average", a, b.notNull());
     }
 };
 

--- a/include/open62541cpp/open62541objects.h
+++ b/include/open62541cpp/open62541objects.h
@@ -942,6 +942,11 @@ public:
     //
     // Construct Variant from ...
     // TO DO add array handling
+
+    explicit Variant()
+        : TypeBase(UA_Variant_new())
+    {
+    }
     /*!
         \brief uaVariant
         \param v
@@ -1258,6 +1263,32 @@ class UA_EXPORT VariableAttributes : public TypeBase<UA_VariableAttributes, UA_T
 public:
     using TypeBase<UA_VariableAttributes, UA_TYPES_VARIABLEATTRIBUTES>::operator=;
     void setDefault() { *this = UA_VariableAttributes_default; }
+
+
+    //feat: Add member function for array dimension and size
+    template <typename T>
+    Variant getVariantMatrix(const UA_UInt32 rows, const UA_UInt32 cols,const size_t dim_size, const UA_DataType *type,const int value_rank,const T* array) 
+    {
+        *this = UA_VariableAttributes_default;
+        Variant variant;
+        //set the VariableAttribute values' constraints
+        get().valueRank = value_rank;
+        get().dataType = type->typeId;
+        get().arrayDimensions = (UA_UInt32 *)UA_Array_new(dim_size, type);
+        get().arrayDimensionsSize = dim_size;
+        get().arrayDimensions[0]=rows;
+        get().arrayDimensions[1]=cols;
+        
+        //Set the value from the argument array. The array dimensions need to be the same for the value
+        size_t arraySize = sizeof(*array) / sizeof(array);
+        UA_Variant_setArrayCopy(&get().value, array, arraySize, type);
+        get().value.arrayDimensions = (UA_UInt32 *)UA_Array_new(dim_size, type);
+        get().value.arrayDimensionsSize = dim_size;
+        get().value.arrayDimensions[0]=rows;
+        get().value.arrayDimensions[1]=cols;
+        UA_Variant_copy(&get().value, variant);
+        return variant;
+    }
 
     void setDisplayName(const std::string& s) { get().displayName = UA_LOCALIZEDTEXT_ALLOC("en_US", s.c_str()); }
     void setDescription(const std::string& s) { get().description = UA_LOCALIZEDTEXT_ALLOC("en_US", s.c_str()); }

--- a/include/open62541cpp/serverobjecttype.h
+++ b/include/open62541cpp/serverobjecttype.h
@@ -128,6 +128,55 @@ public:
         return false;
     }
 
+    //=========feat:addObjectTypeArrayVariable============//
+    template <typename T, size_t size_array>
+    bool addObjectTypeArrayVariable(const std::string& n,
+                               const NodeId& parent,
+                               NodeId& nodeId              = NodeId::Null,
+                               NodeContext* context        = nullptr,
+                               const NodeId& requestNodeId = NodeId::Null,  // usually want auto generated ids
+                               bool mandatory              = true)
+    {
+        T a[size_array]{};
+        T type{};
+        Variant value(type);
+        VariableAttributes var_attr;
+        //
+        var_attr.setDefault();
+        var_attr.setDisplayName(n);
+        var_attr.setDescription(n);
+        var_attr.get().accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+        Variant variant_array;
+        variant_array.setArrayCopy(&a, size_array, value.get().type);
+        var_attr.setValue(variant_array);
+        //
+        QualifiedName qn(_nameSpace, n.c_str());
+        //
+        NodeId newNode;
+        newNode.notNull();
+        //
+        if (_server.addVariableNode(requestNodeId,
+                                    parent,
+                                    NodeId::HasComponent,
+                                    qn,
+                                    NodeId::BaseDataVariableType,
+                                    var_attr,
+                                    newNode,
+                                    context)) {
+            if (mandatory) {
+                return _server.addReference(newNode,
+                                            NodeId::HasModellingRule,
+                                            ExpandedNodeId::ModellingRuleMandatory,
+                                            true);
+            }
+            if (!nodeId.isNull())
+                nodeId = newNode;
+            return true;
+        }
+        UAPRINTLASTERROR(_server.lastError())
+        return false;
+    }
+
     bool addObjectTypeFolder(const std::string& childName,
                              NodeId& parent,
                              NodeId& nodeId,


### PR DESCRIPTION
add Variant type constructor with no args, a method for creating matrices, improved TestServer example with add arrays and arrays in objectType